### PR TITLE
Return empty message on kill request

### DIFF
--- a/moteur_server.cpp
+++ b/moteur_server.cpp
@@ -43,7 +43,7 @@ int ns__killWorkflow(struct soap * soap, std::string workflowId){
   command+=workflowId;
   command+=" >> ./moteur_service.log";
   system(command.c_str());
-  return SOAP_OK;
+  return soap_send_empty_response(soap, 202); // HTTP 202 Accepted
 }
 
 int ns__getWorkflowStatus(struct soap * soap, std::string workflowId, std::string & workflowStatus)


### PR DESCRIPTION
The kill was effective before but the return value of a soap method returning void was wrong. So the request always returned a 500 error that had to be silenced on the client side.

see : https://www.genivia.com/doc/guide/html/index.html#oneway1